### PR TITLE
Feature/#5

### DIFF
--- a/backend/src/main/java/kr/co/quietpath/api/record/controller/RecordController.java
+++ b/backend/src/main/java/kr/co/quietpath/api/record/controller/RecordController.java
@@ -59,6 +59,7 @@ public class RecordController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @PutMapping("/{recordId}")
     @PatchMapping("/{recordId}")
     public RecordUpdateResponse updateRecord(
         @AuthenticationPrincipal UserPrincipal principal,

--- a/backend/src/main/java/kr/co/quietpath/api/record/dto/request/RecordCreateRequest.java
+++ b/backend/src/main/java/kr/co/quietpath/api/record/dto/request/RecordCreateRequest.java
@@ -13,6 +13,8 @@ public class RecordCreateRequest {
     @NotBlank
     private String content;
 
+    private String moodCode;
+
     @NotBlank
     private String visibility;
 }

--- a/backend/src/main/java/kr/co/quietpath/api/record/dto/request/RecordUpdateRequest.java
+++ b/backend/src/main/java/kr/co/quietpath/api/record/dto/request/RecordUpdateRequest.java
@@ -13,6 +13,8 @@ public class RecordUpdateRequest {
     @NotBlank
     private String content;
 
+    private String moodCode;
+
     @NotBlank
     private String visibility;
 }

--- a/backend/src/main/java/kr/co/quietpath/api/record/dto/response/RecordCreateResponse.java
+++ b/backend/src/main/java/kr/co/quietpath/api/record/dto/response/RecordCreateResponse.java
@@ -10,6 +10,7 @@ public class RecordCreateResponse {
     private Long pathId;
     private String recordDate;
     private String content;
+    private String moodCode;
     private String visibility;
     private String createdAt;
 }

--- a/backend/src/main/java/kr/co/quietpath/api/record/dto/response/RecordDetailResponse.java
+++ b/backend/src/main/java/kr/co/quietpath/api/record/dto/response/RecordDetailResponse.java
@@ -10,6 +10,7 @@ public class RecordDetailResponse {
     private Long pathId;
     private String recordDate;
     private String content;
+    private String moodCode;
     private String visibility;
     private OwnerSummary owner;
     private long reactionCount;

--- a/backend/src/main/java/kr/co/quietpath/api/record/dto/response/RecordTodayResponse.java
+++ b/backend/src/main/java/kr/co/quietpath/api/record/dto/response/RecordTodayResponse.java
@@ -10,6 +10,7 @@ public class RecordTodayResponse {
     private Long pathId;
     private String recordDate;
     private String content;
+    private String moodCode;
     private String visibility;
     private String createdAt;
 }

--- a/backend/src/main/java/kr/co/quietpath/api/record/dto/response/RecordUpdateResponse.java
+++ b/backend/src/main/java/kr/co/quietpath/api/record/dto/response/RecordUpdateResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public class RecordUpdateResponse {
     private Long id;
     private String content;
+    private String moodCode;
     private String visibility;
     private String updatedAt;
 }

--- a/backend/src/main/java/kr/co/quietpath/api/record/service/RecordService.java
+++ b/backend/src/main/java/kr/co/quietpath/api/record/service/RecordService.java
@@ -17,6 +17,7 @@ import kr.co.quietpath.domain.record.repository.RecordRepository;
 import kr.co.quietpath.domain.user.entity.User;
 import kr.co.quietpath.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +35,7 @@ public class RecordService {
     private static final String STATUS_ACTIVE = "ACTIVE";
     private static final String VISIBILITY_PUBLIC = "PUBLIC";
     private static final String VISIBILITY_PRIVATE = "PRIVATE";
+    private static final Set<String> ALLOWED_MOOD_CODES = Set.of("포근", "멍함", "반짝", "잔잔", "버팀", "두근");
 
     private final RecordRepository recordRepository;
     private final UserRepository userRepository;
@@ -55,6 +58,7 @@ public class RecordService {
         }
 
         String visibility = normalizeVisibility(request.getVisibility());
+        String moodCode = normalizeMoodCode(request.getMoodCode());
 
         Record record = Record.builder()
             .user(user)
@@ -64,10 +68,14 @@ public class RecordService {
             .sceneText(request.getContent())
             .oneWordText(null)
             .tomorrowText(null)
-            .moodCode(null)
+            .moodCode(moodCode)
             .build();
 
-        recordRepository.save(record);
+        try {
+            recordRepository.save(record);
+        } catch (DataIntegrityViolationException ex) {
+            throw new ApiException(ErrorCode.RECORD_ALREADY_EXISTS);
+        }
 
         if (VISIBILITY_PUBLIC.equals(visibility)) {
             record.share();
@@ -78,6 +86,7 @@ public class RecordService {
             .pathId(activePath.getId())
             .recordDate(formatDate(today))
             .content(resolveContent(record))
+            .moodCode(record.getMoodCode())
             .visibility(record.getVisibility())
             .createdAt(formatDateTime(record.getCreatedAt()))
             .build();
@@ -92,6 +101,7 @@ public class RecordService {
                 .pathId(record.getPath().getId())
                 .recordDate(formatDate(record.getRecordDate()))
                 .content(resolveContent(record))
+                .moodCode(record.getMoodCode())
                 .visibility(record.getVisibility())
                 .createdAt(formatDateTime(record.getCreatedAt()))
                 .build())
@@ -127,6 +137,7 @@ public class RecordService {
             .pathId(record.getPath() != null ? record.getPath().getId() : null)
             .recordDate(formatDate(record.getRecordDate()))
             .content(resolveContent(record))
+            .moodCode(record.getMoodCode())
             .visibility(record.getVisibility())
             .owner(ownerSummary)
             .reactionCount(reactionCount)
@@ -141,12 +152,13 @@ public class RecordService {
         Record record = getRecord(recordId);
         validateOwner(userId, record);
         validateEditable(record);
+        String moodCode = normalizeMoodCode(request.getMoodCode());
 
         record.updateContent(
             request.getContent(),
             record.getOneWordText(),
             record.getTomorrowText(),
-            record.getMoodCode()
+            moodCode
         );
 
         String visibility = normalizeVisibility(request.getVisibility());
@@ -155,6 +167,7 @@ public class RecordService {
         return RecordUpdateResponse.builder()
             .id(record.getId())
             .content(resolveContent(record))
+            .moodCode(record.getMoodCode())
             .visibility(record.getVisibility())
             .updatedAt(formatDateTime(record.getUpdatedAt()))
             .build();
@@ -210,6 +223,16 @@ public class RecordService {
             return VISIBILITY_PRIVATE;
         }
         throw new ApiException(ErrorCode.INVALID_REQUEST);
+    }
+
+    private String normalizeMoodCode(String moodCode) {
+        if (moodCode == null || moodCode.isBlank()) {
+            return null;
+        }
+        if (!ALLOWED_MOOD_CODES.contains(moodCode)) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST);
+        }
+        return moodCode;
     }
 
     private void applyVisibility(Record record, String visibility) {

--- a/backend/src/test/java/kr/co/quietpath/api/record/service/RecordServiceTest.java
+++ b/backend/src/test/java/kr/co/quietpath/api/record/service/RecordServiceTest.java
@@ -4,7 +4,10 @@ import kr.co.quietpath.api.common.error.ApiException;
 import kr.co.quietpath.api.common.error.ErrorCode;
 import kr.co.quietpath.api.record.dto.request.RecordCreateRequest;
 import kr.co.quietpath.api.record.dto.request.RecordUpdateRequest;
+import kr.co.quietpath.api.record.dto.response.RecordCreateResponse;
+import kr.co.quietpath.domain.comment.repository.CommentRepository;
 import kr.co.quietpath.domain.path.entity.Path;
+import kr.co.quietpath.domain.reaction.repository.ReactionRepository;
 import kr.co.quietpath.domain.record.entity.Record;
 import kr.co.quietpath.domain.record.repository.RecordRepository;
 import kr.co.quietpath.domain.user.entity.User;
@@ -22,6 +25,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +36,12 @@ class RecordServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private ReactionRepository reactionRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
 
     @InjectMocks
     private RecordService recordService;
@@ -52,6 +62,33 @@ class RecordServiceTest {
 
         ApiException ex = assertThrows(ApiException.class, () -> recordService.createRecord(1L, request));
         assertEquals(ErrorCode.RECORD_ALREADY_EXISTS, ex.getErrorCode());
+    }
+
+    @Test
+    void createRecord_storesMoodCodeInRecordAndResponse() {
+        User user = User.createGoogle("provider", "user@example.com", "nick");
+        setId(user, 1L);
+        Path activePath = buildPath(1L);
+        user.setActivePath(activePath);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(recordRepository.existsByUser_IdAndRecordDate(1L, LocalDate.now()))
+            .thenReturn(false);
+        when(recordRepository.save(any(Record.class))).thenAnswer(invocation -> {
+            Record savedRecord = invocation.getArgument(0);
+            setId(savedRecord, 100L);
+            return savedRecord;
+        });
+
+        RecordCreateRequest request = new RecordCreateRequest();
+        request.setContent("오늘은 꽤 단단했다");
+        request.setMoodCode("버팀");
+        request.setVisibility("PRIVATE");
+
+        RecordCreateResponse response = recordService.createRecord(1L, request);
+
+        assertEquals(100L, response.getId());
+        assertEquals("버팀", response.getMoodCode());
     }
 
     @Test
@@ -79,6 +116,37 @@ class RecordServiceTest {
 
         ApiException ex = assertThrows(ApiException.class, () -> recordService.updateRecord(2L, 10L, request));
         assertEquals(ErrorCode.NOT_OWNER, ex.getErrorCode());
+    }
+
+    @Test
+    void updateRecord_updatesMoodCodeWithoutCreatingNewRecord() {
+        User owner = User.createGoogle("provider", "owner@example.com", "owner");
+        setId(owner, 1L);
+        Path activePath = buildPath(1L);
+        Record record = Record.builder()
+            .user(owner)
+            .path(activePath)
+            .categoryCode("DEFAULT")
+            .recordDate(LocalDate.now())
+            .sceneText("기존 내용")
+            .oneWordText(null)
+            .tomorrowText(null)
+            .moodCode("잔잔")
+            .build();
+        setId(record, 10L);
+
+        when(recordRepository.findById(10L)).thenReturn(Optional.of(record));
+
+        RecordUpdateRequest request = new RecordUpdateRequest();
+        request.setContent("수정 내용");
+        request.setMoodCode("반짝");
+        request.setVisibility("PRIVATE");
+
+        var response = recordService.updateRecord(1L, 10L, request);
+
+        assertEquals(10L, response.getId());
+        assertEquals("반짝", response.getMoodCode());
+        assertEquals("반짝", record.getMoodCode());
     }
 
     private Path buildPath(Long id) {

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -163,23 +163,25 @@ const App: React.FC = () => {
     return (
       <button
         onClick={() => setCurrentView(view)}
-        className="flex flex-col items-center justify-center gap-1.5 transition-all duration-500 ease-out group flex-1"
+        className="relative flex flex-col items-center justify-center flex-1 h-full group pointer-events-auto"
       >
         <div
           className={[
-            'w-16 h-16 rounded-[22px] flex items-center justify-center transition-all duration-500 ease-out',
+            'w-[44px] h-[44px] rounded-[15px] flex items-center justify-center transition-all duration-500 ease-out z-10',
             isActive
-              ? 'bg-gradient-to-br from-[#9F75FF] to-[#8B5CF6] shadow-[0_8px_20px_rgba(139,92,246,0.3)] -translate-y-2 scale-110'
-              : 'bg-transparent hover:bg-white/40',
+              ? 'bg-gradient-to-br from-[#9F75FF] to-[#8B5CF6] shadow-[0_4px_12px_rgba(139,92,246,0.25)] -translate-y-[10px] scale-110'
+              : 'bg-transparent hover:bg-white/40 group-hover:-translate-y-1',
           ].join(' ')}
         >
-          <div className={`transition-transform duration-500 ${isActive ? 'scale-110' : 'group-hover:scale-105 group-active:scale-95'}`}>
+          <div className={`transition-transform duration-500 ${isActive ? 'scale-110' : 'group-hover:scale-110'}`}>
             <NavIcon view={view} active={isActive} />
           </div>
         </div>
         <span
-          className={`text-[10px] font-bold tracking-tight transition-all duration-500 ${
-            isActive ? 'text-[#8B5CF6] opacity-100' : 'text-slate-400 opacity-0 group-hover:opacity-40'
+          className={`absolute bottom-[3px] text-[9px] font-bold tracking-tight transition-all duration-500 ${
+            isActive 
+              ? 'text-[#8B5CF6] opacity-100 translate-y-0' 
+              : 'text-slate-400 opacity-0 translate-y-2 group-hover:opacity-100 group-hover:translate-y-0'
           }`}
         >
           {label}
@@ -205,13 +207,25 @@ const App: React.FC = () => {
   return (
     <div className="min-h-screen max-w-md mx-auto dream-bg relative shadow-2xl shadow-mist-200/40 flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       
+      {/* Header Overlay (Gradient Blur) */}
+      <div 
+        className="sticky top-0 h-20 -mb-20 z-20 pointer-events-none transition-opacity duration-500"
+        style={{
+          backdropFilter: 'blur(10px)',
+          WebkitBackdropFilter: 'blur(10px)',
+          maskImage: 'linear-gradient(to bottom, black 40%, transparent 100%)',
+          WebkitMaskImage: 'linear-gradient(to bottom, black 40%, transparent 100%)',
+          backgroundColor: 'rgba(255, 255, 255, 0.4)'
+        }}
+      />
+
       {/* Top Bar */}
-      <div className="h-16 flex items-center justify-between px-8 z-10 sticky top-0 bg-transparent">
+      <div className="h-14 flex items-center justify-between px-8 z-30 sticky top-0 bg-transparent">
         <div className="w-6" />
         <h1 className="text-mist-400 text-[10px] font-bold tracking-[0.3em] uppercase opacity-70">Quiet Path</h1>
         <button 
           onClick={() => setCurrentView('SETTINGS')} 
-          className="text-mist-300 hover:text-mist-500 transition-colors p-2 rounded-full hover:bg-white/40"
+          className="text-mist-400 hover:text-purple-500 transition-all p-2 rounded-full hover:bg-white/40 active:scale-95"
         >
           <Settings size={18} />
         </button>
@@ -276,8 +290,8 @@ const App: React.FC = () => {
 
       {/* Floating Bottom Navigation */}
       {currentView !== 'WRITE_LOG' && (
-        <div className="fixed bottom-10 left-0 w-full flex justify-center z-20 px-6 pointer-events-none">
-           <nav className="h-24 px-4 bg-white/90 backdrop-blur-2xl border border-white/80 rounded-[40px] shadow-[0_12px_40px_rgba(0,0,0,0.06)] flex items-center justify-between w-full max-w-[360px] pointer-events-auto">
+        <div className="fixed bottom-6 left-0 w-full flex justify-center z-20 px-6 pointer-events-none">
+           <nav className="h-[64px] px-2 bg-white/94 backdrop-blur-2xl border border-white/80 rounded-[28px] shadow-[0_12px_40px_rgba(0,0,0,0.06)] flex items-center justify-between w-full max-w-[340px] pointer-events-auto">
             <NavItem view="NOW" label="오늘" />
             <NavItem view="RECORDS" label="기록" />
             <NavItem view="COMMUNITY" label="둘러보기" />

--- a/frontend/components/CurrentPathStrip.tsx
+++ b/frontend/components/CurrentPathStrip.tsx
@@ -19,59 +19,59 @@ export const CurrentPathStrip: React.FC<CurrentPathStripProps> = ({
     : null;
 
   const cat = CATEGORIES.find(c => c.id === currentDirection?.categoryId);
+  const accentColor = cat?.accent || '#8B5CF6';
 
   return (
     <Card
-      className="!rounded-[2.5rem] !p-7 border-white/60 shadow-md !transition-all !duration-300"
-      style={{
-        background: cat
-          ? `linear-gradient(135deg, ${cat.accentBg}66, rgba(255,255,255,0.8))`
-          : 'rgba(255,255,255,0.7)',
-      }}
+      className="!rounded-[2rem] !p-5 !bg-white/85 backdrop-blur-md border-white/50 shadow-sm !transition-all !duration-300"
     >
-      {/* Decorative glow */}
-      <div
-        className="absolute top-0 right-0 w-40 h-40 rounded-full blur-3xl -translate-y-1/2 translate-x-1/2 pointer-events-none opacity-40"
-        style={{ background: cat ? `${cat.accentBg}` : 'rgba(196,181,253,0.3)' }}
-      />
-
-      <div className="flex items-start gap-6 relative z-10">
-        {/* Category Section: Name above Icon */}
-        <div className="flex flex-col items-center gap-2.5 shrink-0">
-          <span className="text-[11px] font-bold tracking-wider" style={{ color: cat?.accent ?? '#8B5CF6' }}>
+      <div className="flex items-center gap-5 relative z-10">
+        {/* Category Section: Icon with subtle background circle */}
+        <div className="flex flex-col items-center gap-2 shrink-0">
+          <span className="text-[10px] font-bold tracking-wider mb-1" style={{ color: accentColor }}>
             {cat?.label || 'Path'}
           </span>
-          <CategoryIcon categoryId={currentDirection?.categoryId} size="lg" className="!rounded-[1.75rem] shadow-lg" />
+          <div className="relative">
+             <div 
+               className="absolute inset-0 rounded-full blur-md opacity-20"
+               style={{ backgroundColor: accentColor }}
+             />
+             <CategoryIcon 
+               categoryId={currentDirection?.categoryId} 
+               size="lg" 
+               className="!rounded-full shadow-sm relative z-10 border border-white" 
+             />
+          </div>
         </div>
 
-        {/* Content Section: Title and Question aligned */}
-        <div className="flex-1 min-w-0 flex flex-col justify-center pt-5">
-          <h3 className="text-[19px] font-bold text-mist-600 leading-snug break-keep mb-2">
+        {/* Content Section: Title and Question */}
+        <div className="flex-1 min-w-0 flex flex-col justify-center">
+          <h3 className="text-[17px] font-bold text-mist-600 leading-snug break-keep mb-1.5">
             {currentDirection?.description || '아직 설정된 여정이 없어요'}
           </h3>
           {currentDirection?.question && (
-            <p className="text-[13px] text-mist-400 font-medium leading-relaxed break-keep opacity-80 border-l-2 border-mist-100 pl-3">
+            <p className="text-[12px] text-mist-400 font-medium leading-relaxed break-keep line-clamp-1 opacity-80">
               {currentDirection.question}
             </p>
           )}
         </div>
 
         {/* Info Section: Consistency & Review Date */}
-        <div className="flex flex-col items-end shrink-0 gap-3 pt-1">
+        <div className="flex flex-col items-end shrink-0 gap-2.5">
           <div className="text-right">
-            <div className="flex items-baseline justify-end gap-1">
-              <span className="text-2xl font-black tracking-tighter" style={{ color: cat?.accent ?? '#8B5CF6' }}>
+            <div className="flex items-baseline justify-end gap-0.5">
+              <span className="text-2xl font-black tracking-tighter" style={{ color: accentColor }}>
                 {currentPathConsistency}
               </span>
               <span className="text-[10px] font-bold text-mist-300">%</span>
             </div>
-            <p className="text-[9px] font-bold text-mist-300 uppercase tracking-widest mt-0.5">Focus</p>
+            <p className="text-[8px] font-bold text-mist-300 uppercase tracking-widest mt-0.5">Focus</p>
           </div>
           
           {reviewDateText && (
-            <div className="flex items-center gap-1.5 bg-white/80 px-3 py-1.5 rounded-full border border-mist-100 shadow-sm">
+            <div className="flex items-center gap-1 bg-white px-2.5 py-1 rounded-full border border-mist-100 shadow-sm">
               <Compass size={10} className="text-point-400" />
-              <span className="text-[10px] font-bold text-mist-500">
+              <span className="text-[9px] font-bold text-mist-500">
                 ~ {reviewDateText}
               </span>
             </div>

--- a/frontend/components/ProgressBand.tsx
+++ b/frontend/components/ProgressBand.tsx
@@ -19,12 +19,12 @@ export const ProgressBand: React.FC<ProgressBandProps> = ({
   return (
     <div className="flex flex-col gap-3">
        {/* 1. Streak Heatmap Section */}
-      <Card className="!bg-white/70 border border-white/50 shadow-sm !p-5">
+      <Card className="!bg-white/85 backdrop-blur-md border border-white/50 shadow-sm !p-5">
         <StreakHeatmap records={records} />
       </Card>
 
       {/* 2. Monthly Summary Stats */}
-      <Card className="!bg-white/55 border border-white/50 shadow-sm backdrop-blur-sm !p-5">
+      <Card className="!bg-white/85 backdrop-blur-md border border-white/50 shadow-sm !p-5">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
             <Flame size={16} className="text-point-400" />

--- a/frontend/components/TodaysCard.tsx
+++ b/frontend/components/TodaysCard.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import { Record } from '../types';
+import React, { useState } from 'react';
+import { Record as RecordType } from '../types';
 import { Card, SoftButton, MoodSticker } from './UI';
-import { PenLine, RefreshCw, Share2 } from 'lucide-react';
-import { WaterDropCharacter } from './WaterDropCharacter';
+import { RefreshCw, Share2, Sparkles, MessageCircle, Globe, Link as LinkIcon, PenLine } from 'lucide-react';
+import { WaterDropCharacter, CharacterMood } from './WaterDropCharacter';
 
 interface TodaysCardProps {
   hasLoggedToday: boolean;
-  todayRecord: Record | null;
+  todayRecord: RecordType | null;
   onLogClick: () => void;
   onEditClick: () => void;
 }
@@ -17,24 +17,25 @@ export const TodaysCard: React.FC<TodaysCardProps> = ({
   onLogClick, 
   onEditClick 
 }) => {
+  const [showShareMenu, setShowShareMenu] = useState(false);
+
   // 1. Before Record State — character waits for you
   if (!hasLoggedToday) {
     return (
-      <Card className="!bg-white/85 shadow-md border border-white/60">
+      <Card className="!bg-white/85 backdrop-blur-md border border-white/50 shadow-sm !p-6 hover:scale-[1.01] hover:shadow-md transition-all duration-300">
         <div className="flex items-center gap-5">
           <div className="shrink-0">
-            <WaterDropCharacter size={100} mood="waiting" animate={true} />
+            <WaterDropCharacter size={90} mood="waiting" animate={true} />
           </div>
           <div className="flex-1">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-mist-300 mb-2">Today&apos;s Record</p>
-            <h2 className="text-xl font-bold text-mist-600 leading-tight break-keep">오늘 남기고 싶은<br/>장면이 있나요?</h2>
-            <p className="text-sm text-mist-400 mt-2 break-keep">한 줄만 남겨도 충분해요.</p>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-point-300 mb-2">Today&apos;s Record</p>
+            <h2 className="text-lg font-bold text-mist-600 leading-tight break-keep">오늘 남기고 싶은<br/>장면이 있나요?</h2>
           </div>
         </div>
-        <div className="mt-5">
-          <SoftButton onClick={onLogClick} className="!py-4 shadow-lg shadow-point-200/40">
-            <PenLine size={18} />
-            <span className="text-base font-semibold">기록 남기기</span>
+        <div className="mt-4">
+          <SoftButton onClick={onLogClick} className="!py-3 shadow-lg shadow-point-200/30">
+            <PenLine size={16} />
+            <span className="text-sm font-semibold">기록 남기기</span>
           </SoftButton>
         </div>
       </Card>
@@ -47,7 +48,7 @@ export const TodaysCard: React.FC<TodaysCardProps> = ({
 
     return (
       <Card 
-        className={`!p-0 relative overflow-hidden shadow-lg ${hasImage ? '!border-transparent text-white' : 'border-white/40 bg-gradient-to-br from-mist-50 to-white'}`}
+        className={`!p-0 relative overflow-hidden transition-all duration-500 shadow-sm border-white/50 hover:scale-[1.01] hover:shadow-md group ${hasImage ? '!border-transparent text-white' : '!bg-white/85 backdrop-blur-md'}`}
       >
         {/* Background Image Setup */}
         {hasImage && (
@@ -57,49 +58,102 @@ export const TodaysCard: React.FC<TodaysCardProps> = ({
               style={{ backgroundImage: `url(${todayRecord.imageUrl})` }}
             />
             {/* Dark overlay for text readability on images */}
-            <div className="absolute inset-0 bg-black/40 backdrop-blur-[2px] z-0" />
+            <div className="absolute inset-0 bg-black/45 backdrop-blur-[1px] z-0" />
           </>
         )}
 
-        <div className="relative z-10 flex flex-col h-full min-h-[160px] justify-between p-6">
+        <div className="relative z-10 flex flex-col h-full justify-between p-5 pb-4">
           <div className="flex-1">
-            <div className="flex items-center justify-between mb-4">
-               <div className="flex items-center gap-3">
-                 <WaterDropCharacter size={40} mood="happy" className="shrink-0" />
-                 <p className={`text-[10px] font-bold uppercase tracking-widest ${hasImage ? 'text-white/80' : 'text-mist-400'}`}>Today&apos;s Card</p>
+            <div className="flex items-center justify-between mb-3">
+               <div className="flex items-center gap-4">
+                 <WaterDropCharacter 
+                   size={48} 
+                   mood={todayRecord.moodCode as CharacterMood} 
+                   animate={true}
+                   className="shrink-0 drop-shadow-sm" 
+                 />
+                 <p className={`text-[11px] font-bold uppercase tracking-[0.25em] ${hasImage ? 'text-white/85' : 'text-mist-400'}`}>Today&apos;s Card</p>
                </div>
-               {todayRecord.moodCode && <MoodSticker code={todayRecord.moodCode} className="opacity-100" />}
+               {/* Recent Mood (MoodSticker) */}
+               {todayRecord.moodCode && <MoodSticker code={todayRecord.moodCode} className="opacity-100 shadow-sm scale-90 origin-right" />}
             </div>
             
-            <h2 className={`text-2xl font-bold leading-tight mb-3 break-keep ${hasImage ? 'text-white' : 'text-mist-700'}`}>
+            <h2 className={`text-[20px] font-bold leading-tight mb-1.5 break-keep ${hasImage ? 'text-white' : 'text-mist-600'}`}>
               {todayRecord.action || "오늘의 장면"}
             </h2>
 
             {todayRecord.oneWordText && (
-              <p className={`text-[15px] leading-relaxed break-keep ${hasImage ? 'text-white/90' : 'text-mist-600'}`}>
+              <p className={`text-[13px] leading-relaxed break-keep font-medium ${hasImage ? 'text-white/90' : 'text-mist-400'}`}>
                 {todayRecord.oneWordText}
               </p>
             )}
           </div>
 
-          <div className="mt-8 flex items-center justify-end gap-2 shrink-0">
-            <SoftButton 
-              variant="secondary" 
-              onClick={onEditClick} 
-              className={`!flex-none !w-auto !py-2.5 !px-4 !text-xs !rounded-xl min-w-[90px] ${hasImage ? 'bg-white/20 text-white border-white/30 hover:bg-white/30' : ''}`}
-            >
-              <RefreshCw size={14} className="mr-1" />
-              수정하기
-            </SoftButton>
-             <SoftButton 
-              variant="secondary" 
-              onClick={() => { /* share logic */ }} 
-              className={`!flex-none !w-auto !py-2.5 !px-3.5 !rounded-xl ${hasImage ? 'bg-white/20 text-white border-white/30 hover:bg-white/30' : ''}`}
-            >
-              <Share2 size={14} />
-            </SoftButton>
+          <div className="mt-4 flex items-center justify-between gap-3 shrink-0 pt-3 relative">
+            {!hasImage ? (
+              <div className="flex items-center gap-2 text-mist-300">
+                <Sparkles size={12} className="opacity-70" />
+                <span className="text-[10px] font-medium tracking-tight">장면을 남기면 배경 이미지로 바껴요 ✨</span>
+              </div>
+            ) : <div />}
+
+            <div className="flex items-center gap-2">
+              <button 
+                onClick={onEditClick} 
+                className={`flex items-center justify-center gap-1.5 py-2.5 px-6 rounded-full border transition-all ${hasImage ? 'bg-white/20 text-white border-white/30 hover:bg-white/30' : 'bg-white border-mist-200 text-mist-600 shadow-sm hover:bg-mist-50'}`}
+              >
+                <RefreshCw size={14} />
+                <span className="text-[13px] font-bold tracking-tight">수정</span>
+              </button>
+              
+              <div className="relative">
+                <button 
+                  onClick={() => setShowShareMenu(!showShareMenu)} 
+                  className={`flex items-center justify-center w-10 h-10 rounded-full border transition-all ${hasImage ? 'bg-white/20 text-white border-white/30 hover:bg-white/30' : 'bg-white border-mist-200 text-mist-600 shadow-sm hover:bg-mist-50'} ${showShareMenu ? '!border-mist-400 !bg-mist-100' : ''}`}
+                >
+                  <Share2 size={15} className="-ml-0.5" />
+                </button>
+
+                {/* Sharing Menu Popover */}
+                {showShareMenu && (
+                  <div className="absolute bottom-full right-0 mb-2 w-44 bg-white/95 backdrop-blur-xl border border-mist-100 rounded-[1.25rem] shadow-xl p-1.5 z-50 animate-in fade-in slide-in-from-bottom-2 duration-200">
+                    <div className="flex flex-col gap-0.5">
+                      <button className="flex items-center gap-2.5 w-full p-2 hover:bg-mist-50 rounded-xl transition-colors text-left group/item">
+                        <span className="text-base leading-none">🏛️</span>
+                        <div className="flex flex-col">
+                          <span className="text-[11px] font-bold text-mist-600 mb-0.5">커뮤니티에 공유</span>
+                          <span className="text-[9px] text-mist-400 leading-none">앱 내 기록 공간으로</span>
+                        </div>
+                      </button>
+                      <button className="flex items-center gap-2.5 w-full p-2 hover:bg-mist-50 rounded-xl transition-colors text-left group/item">
+                        <span className="text-base leading-none">💬</span>
+                        <div className="flex flex-col">
+                          <span className="text-[11px] font-bold text-mist-600 mb-0.5">카카오톡 공유</span>
+                          <span className="text-[9px] text-mist-400 leading-none">친구에게 메시지 보내기</span>
+                        </div>
+                      </button>
+                      <button className="flex items-center gap-2.5 w-full p-2 hover:bg-mist-50 rounded-xl transition-colors text-left group/item">
+                        <span className="text-base leading-none">🔗</span>
+                        <div className="flex flex-col">
+                          <span className="text-[11px] font-bold text-mist-600 mb-0.5">링크 복사</span>
+                          <span className="text-[9px] text-mist-400 leading-none">URL을 복사합니다</span>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
         </div>
+
+        {/* Backdrop to close share menu when clicking outside */}
+        {showShareMenu && (
+          <div 
+            className="fixed inset-0 z-40 bg-transparent" 
+            onClick={() => setShowShareMenu(false)}
+          />
+        )}
       </Card>
     );
   }

--- a/frontend/components/UI.tsx
+++ b/frontend/components/UI.tsx
@@ -537,10 +537,18 @@ export const VisualTrace: React.FC<{ index: number }> = ({ index }) => {
   );
 };
 // ── Water Drop Micro-interaction Overlay ──
-import { WaterDropCharacter } from './WaterDropCharacter';
+import { WaterDropCharacter, CharacterMood } from './WaterDropCharacter';
 
-export const WaterDropOverlay: React.FC<{ leaving?: boolean }> = ({
+export const WaterDropOverlay: React.FC<{ 
+  leaving?: boolean;
+  mood?: CharacterMood;
+  title?: string;
+  subtitle?: string;
+}> = ({
   leaving = false,
+  mood = 'happy',
+  title = "오늘의 장면이 담겼어요",
+  subtitle = "하루를 잘 기록했어요 ✨"
 }) => {
   const droplets = [
     { dx: '-28px', dy: '-36px', delay: '0.28s', size: 8 },
@@ -568,9 +576,9 @@ export const WaterDropOverlay: React.FC<{ leaving?: boolean }> = ({
           />
         ))}
 
-        {/* Happy character instead of plain emoji */}
+        {/* Mascot dynamic mood */}
         <div className="drop-icon relative z-10">
-          <WaterDropCharacter size={86} mood="happy" animate={false} />
+          <WaterDropCharacter size={86} mood={mood} animate={false} />
         </div>
 
         {droplets.map((d, i) => (
@@ -589,10 +597,10 @@ export const WaterDropOverlay: React.FC<{ leaving?: boolean }> = ({
       </div>
 
       <p className="success-text mt-8 text-base font-semibold text-point-600 tracking-wide">
-        오늘의 장면이 담겼어요
+        {title}
       </p>
       <p className="success-text mt-1 text-xs text-mist-400" style={{ animationDelay: '0.65s' }}>
-        하루를 잘 기록했어요 ✨
+        {subtitle}
       </p>
     </div>
   );

--- a/frontend/components/WaterDropCharacter.tsx
+++ b/frontend/components/WaterDropCharacter.tsx
@@ -1,39 +1,50 @@
 import React from 'react';
 
 // Transparent PNG Mascot Image Paths (Using dist/assets as requested)
-const mascotPurple = '/assets/mascot/mascot_3d_purple.png';
-const mascotCalm = '/assets/mascot/mascot_3d_calm.png';
-const mascotHappy = '/assets/mascot/mascot_3d_happy.png';
-const mascotGray = '/assets/mascot/mascot_3d_gray.png';
+const mascotPurple = '/dist/assets/mascot/mascot_3d_purple.png';
+const mascotCalm = '/dist/assets/mascot/mascot_3d_calm.png';
+const mascotHappy = '/dist/assets/mascot/mascot_3d_happy.png';
+const mascotGray = '/dist/assets/mascot/mascot_3d_gray.png';
+const mascotSparkle = '/dist/assets/mascot/mascot_3d_sparkle.png';
+const mascotMint = '/dist/assets/mascot/mascot_3d_mint.png';
+const mascotBlank = '/dist/assets/mascot/mascot_3d_gray.png';
 
-export type CharacterMood = 'waiting' | '포근' | '멍함' | '반짝' | '잔잔' | '버팀' | '두근' | 'happy' | 'neutral';
+export type CharacterMood = 'waiting' | '포근' | '멍함' | '망함' | '반짝' | '잔잔' | '버팀' | '두근' | 'happy' | 'neutral' | 'default';
+export type CharacterTone = CharacterMood;
 
 interface WaterDropCharacterProps {
   size?: number;
   mood?: CharacterMood;
+  tone?: CharacterTone; // Compatibility for legacy 'tone' prop
   className?: string;
   animate?: boolean;
 }
 
 export const WaterDropCharacter: React.FC<WaterDropCharacterProps> = ({
   size = 100,
-  mood = 'waiting',
+  mood,
+  tone,
   className = '',
   animate = true,
 }) => {
+  // Use mood if provided, otherwise fallback to tone
+  const activeMood = mood || tone || 'waiting';
   // Map moods to transparent PNG images in public folder
   const getMascotImage = (m: CharacterMood) => {
     switch (m) {
       case '잔잔':
         return mascotCalm;
       case '반짝':
+        return mascotSparkle;
       case '두근':
       case 'happy':
         return mascotHappy;
       case '멍함':
-        return mascotGray;
-      case '포근':
+      case '망함':
+        return mascotBlank;
       case '버팀':
+        return mascotMint;
+      case '포근':
       case 'waiting':
       case 'neutral':
       default:
@@ -41,11 +52,11 @@ export const WaterDropCharacter: React.FC<WaterDropCharacterProps> = ({
     }
   };
 
-  const mascotSrc = getMascotImage(mood);
+  const mascotSrc = getMascotImage(activeMood);
 
   // Animation Styles
   const animationStyle = animate ? {
-    animation: mood === 'waiting' 
+    animation: (activeMood === 'waiting' || activeMood === 'neutral' || activeMood === 'default')
       ? 'float 3s ease-in-out infinite' 
       : 'breathe 4s ease-in-out infinite'
   } : {};

--- a/frontend/components/records/AlbumTab.tsx
+++ b/frontend/components/records/AlbumTab.tsx
@@ -11,11 +11,11 @@ interface AlbumTabProps {
 }
 
 const EmptyAlbum: React.FC<{ mascotTone?: CharacterTone }> = ({ mascotTone = 'default' }) => (
-  <div className="mx-4 mb-8 flex flex-col items-center justify-center text-center py-10 px-6">
-    <WaterDropCharacter size={78} mood="neutral" tone={mascotTone} animate={false} className="mb-1" />
-    <p className="text-sm font-bold text-mist-600 mb-2 mt-2">아직 이번 달 장면이 없어요</p>
-    <p className="text-[12px] text-mist-400 leading-relaxed max-w-[200px]">
-      기록을 남길 때 사진을 첨부하면<br />이곳에 장면 타임라인이 쌓입니다.
+  <div className="mx-4 flex flex-col items-center justify-center text-center py-12 px-6">
+    <WaterDropCharacter size={80} mood="neutral" tone={mascotTone} animate={true} className="mb-4" />
+    <p className="text-sm font-bold text-mist-600 mb-1">아직 이번 달 장면이 없어요</p>
+    <p className="text-[11px] text-mist-400 leading-relaxed opacity-80">
+      오늘의 한 걸음을 사진으로 남겨보세요.<br />이곳에 소중한 장면들이 모입니다.
     </p>
   </div>
 );

--- a/frontend/components/records/CalendarTab.tsx
+++ b/frontend/components/records/CalendarTab.tsx
@@ -50,12 +50,20 @@ const MOOD_LEGEND = [
   { code: '멍함', dot: MOOD_DOT['멍함'] },
 ];
 
-const EmptyCalendar: React.FC = () => (
-  <div className="flex flex-col items-center justify-center py-10 px-6 text-center">
-    <WaterDropCharacter size={78} mood="neutral" tone="default" animate={false} className="mb-1" />
-    <p className="text-sm font-bold text-mist-600 mb-2 mt-2">이번 달 기록이 없어요</p>
-    <p className="text-[12px] text-mist-400 leading-relaxed">
-      기록을 시작하면 달력에서<br />무드와 흐름을 한눈에 볼 수 있어요.
+const NoRecordsGuide: React.FC = () => (
+  <div className="flex flex-col items-center justify-center py-6 px-6 text-center animate-fade-in">
+    <p className="text-sm font-bold text-mist-600 mb-1.5 mt-2 tracking-tight">이번 달 기록이 아직 없어요</p>
+    <p className="text-[11px] text-mist-400 leading-[1.6] opacity-80 font-medium">
+      기록을 시작하면 이곳에서 당신의 무드와 흐름을<br />한눈에 매일매일 확인할 수 있습니다.
+    </p>
+  </div>
+);
+
+const TapGuide: React.FC = () => (
+  <div className="flex flex-col items-center justify-center py-5 px-6 text-center animate-fade-in">
+    <p className="text-[11px] font-bold text-mist-500 mb-1.5 opacity-90 tracking-wide uppercase">Your Mood Journey</p>
+    <p className="text-[10px] text-mist-400 leading-relaxed tracking-wide font-medium">
+      날짜를 탭하면 해당 기록을 바로 열어볼 수 있어요.
     </p>
   </div>
 );
@@ -71,12 +79,12 @@ export const CalendarTab: React.FC<CalendarTabProps> = ({
     (c) => c.type === 'day' && c.record,
   );
 
-  if (!hasAnyRecord) return <EmptyCalendar />;
-
   return (
-    <div className="px-4 pb-6">
+    <div className="px-4 pb-12">
+      {hasAnyRecord ? <TapGuide /> : <NoRecordsGuide />}
+      
       {/* Calendar grid */}
-      <div className="bg-white/80 rounded-[2rem] border border-white/70 shadow-sm overflow-hidden">
+      <div className="bg-white/80 rounded-[2rem] border border-white/70 shadow-sm overflow-hidden mb-6">
         {/* Weekday header */}
         <div className="grid grid-cols-7 bg-mist-50/60 border-b border-mist-100/50">
           {WEEKDAY_LABELS.map((label) => (
@@ -163,7 +171,7 @@ export const CalendarTab: React.FC<CalendarTabProps> = ({
       </div>
 
       {/* Legend */}
-      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 px-1">
+      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 px-1 opacity-80">
         <span className="text-[10px] text-mist-400 font-bold uppercase tracking-widest mr-1">무드</span>
         {MOOD_LEGEND.map(({ code, dot }) => (
           <div key={code} className="flex items-center gap-1">
@@ -176,10 +184,6 @@ export const CalendarTab: React.FC<CalendarTabProps> = ({
           <span className="text-[10px] text-mist-500 font-medium">사진 있음</span>
         </div>
       </div>
-
-      <p className="text-[10px] text-mist-300 mt-3 px-1 tracking-wide">
-        날짜를 탭하면 해당 기록을 바로 열어볼 수 있어요.
-      </p>
     </div>
   );
 };

--- a/frontend/components/records/RecordsListTab.tsx
+++ b/frontend/components/records/RecordsListTab.tsx
@@ -12,11 +12,11 @@ interface RecordsListTabProps {
 }
 
 const EmptyRecords: React.FC = () => (
-  <div className="mx-4 flex flex-col items-center justify-center text-center py-10 px-6">
-    <WaterDropCharacter size={84} mood="waiting" tone="default" animate={true} className="mb-3" />
-    <p className="text-sm font-bold text-mist-600 mb-2">아직 이번 달 기록이 없어요</p>
-    <p className="text-[12px] text-mist-400 leading-relaxed">
-      오늘의 장면을 남겨볼까요?
+  <div className="mx-4 flex flex-col items-center justify-center text-center py-12 px-6">
+    <WaterDropCharacter size={80} mood="waiting" tone="default" animate={true} className="mb-4" />
+    <p className="text-sm font-bold text-mist-600 mb-1">아직 이번 달 기록이 없어요</p>
+    <p className="text-[11px] text-mist-400 leading-relaxed opacity-80">
+      남겨주시는 오늘의 흔적들이<br />이곳에 차곡차곡 쌓일 예정입니다.
     </p>
   </div>
 );
@@ -58,7 +58,9 @@ export const RecordsListTab: React.FC<RecordsListTabProps> = ({
         return (
           <Card
             key={record.id}
-            className={`!p-6 !rounded-[2rem] cursor-pointer hover:shadow-lg transition-all duration-300 relative overflow-hidden ${
+            className={`!p-6 !rounded-[2rem] cursor-pointer hover:shadow-lg transition-all duration-300 relative !overflow-visible ${
+              activeMenuId === record.id ? 'z-50' : 'z-10'
+            } ${
               record.isPinned
                 ? 'bg-white shadow-md border border-point-200'
                 : 'bg-white/80 border border-white/60'
@@ -88,45 +90,81 @@ export const RecordsListTab: React.FC<RecordsListTabProps> = ({
                   </span>
                 )}
               </div>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setActiveMenuId(activeMenuId === record.id ? null : record.id);
-                }}
-                className="text-mist-300 hover:text-mist-500 transition-colors p-2 -mr-2 -mt-2"
-              >
-                <MoreHorizontal size={16} />
-              </button>
-            </div>
-
-            {/* Context Menu */}
-            {activeMenuId === record.id && (
-              <div className="absolute right-6 top-12 bg-white shadow-xl rounded-2xl p-1.5 z-20 border border-mist-100 animate-fade-in min-w-[140px]">
+              <div className="relative">
                 <button
-                  onClick={(e) => { e.stopPropagation(); handlePin(record); }}
-                  className="flex items-center gap-2 px-3 py-2 text-xs font-medium text-mist-600 hover:bg-mist-50 rounded-xl w-full text-left transition-colors"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setActiveMenuId(activeMenuId === record.id ? null : record.id);
+                  }}
+                  className="text-mist-300 hover:text-mist-500 transition-colors p-2 -mr-2 -mt-2"
                 >
-                  <Pin size={14} className="text-mist-400" />
-                  {record.isPinned ? '고정 해제' : '고정하기'}
+                  <MoreHorizontal size={16} />
                 </button>
-                {!record.isShared && (
-                  <button
-                    onClick={(e) => { e.stopPropagation(); handleShare(record); }}
-                    className="flex items-center gap-2 px-3 py-2 text-xs font-bold text-point-500 hover:bg-point-50 rounded-xl w-full text-left transition-colors mt-1"
-                  >
-                    <Share2 size={14} />
-                    커뮤니티 공유
-                  </button>
+                
+                {/* Context Menu */}
+                {activeMenuId === record.id && (
+                  <div className="absolute right-0 top-full mt-1.5 bg-white/95 backdrop-blur-xl border border-mist-100 rounded-[1.25rem] shadow-xl p-1.5 z-50 animate-in fade-in slide-in-from-top-2 duration-200 min-w-[160px]">
+                    <div className="flex flex-col gap-0.5">
+                      <button
+                        onClick={(e) => { e.stopPropagation(); handlePin(record); }}
+                        className="flex items-center gap-2.5 px-3 py-2 text-xs font-bold text-mist-600 hover:bg-mist-50 rounded-xl w-full text-left transition-colors"
+                      >
+                        <Pin size={14} className={record.isPinned ? 'text-amber-500 fill-amber-500' : 'text-mist-400'} />
+                        {record.isPinned ? '고정 해제' : '고정하기'}
+                      </button>
+                      
+                      {/* Categorized Share Options */}
+                      {!record.isShared && (
+                        <div className="my-1 border-t border-mist-50/80" />
+                      )}
+                      {!record.isShared && (
+                        <>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); handleShare(record); }}
+                            className="flex items-center gap-2.5 px-3 py-2 hover:bg-point-50 rounded-xl w-full text-left transition-colors group/btn"
+                          >
+                            <div className="bg-point-100/50 rounded-md p-1 group-hover/btn:bg-point-200/50 transition-colors">
+                              <span className="text-sm leading-none block">🏛️</span>
+                            </div>
+                            <span className="text-[11px] font-bold text-point-500">커뮤니티 공유</span>
+                          </button>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); alert('카카오톡으로 공유합니다.'); setActiveMenuId(null); }}
+                            className="flex items-center gap-2.5 px-3 py-2 hover:bg-mist-50 rounded-xl w-full text-left transition-colors group/btn"
+                          >
+                            <div className="bg-mist-100/50 rounded-md p-1 group-hover/btn:bg-mist-200/50 transition-colors">
+                              <span className="text-sm leading-none block">💬</span>
+                            </div>
+                            <span className="text-[11px] font-bold text-mist-600">카카오톡 공유</span>
+                          </button>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); alert('링크가 복사되었습니다.'); setActiveMenuId(null); }}
+                            className="flex items-center gap-2.5 px-3 py-2 hover:bg-mist-50 rounded-xl w-full text-left transition-colors group/btn"
+                          >
+                            <div className="bg-mist-100/50 rounded-md p-1 group-hover/btn:bg-mist-200/50 transition-colors">
+                              <span className="text-sm leading-none block">🔗</span>
+                            </div>
+                            <span className="text-[11px] font-bold text-mist-600">링크 복사</span>
+                          </button>
+                        </>
+                      )}
+    
+                      <div className="my-1 border-t border-mist-50/80" />
+                      
+                      <button
+                        onClick={(e) => { e.stopPropagation(); handleHide(record); }}
+                        className="flex items-center gap-2.5 px-3 py-2 text-xs font-bold text-red-500 hover:bg-red-50 rounded-xl w-full text-left transition-colors"
+                      >
+                        <div className="bg-red-50 rounded-md p-1 group-hover/btn:bg-red-100 transition-colors">
+                          <EyeOff size={14} className="text-red-400" />
+                        </div>
+                        숨기기
+                      </button>
+                    </div>
+                  </div>
                 )}
-                <button
-                  onClick={(e) => { e.stopPropagation(); handleHide(record); }}
-                  className="flex items-center gap-2 px-3 py-2 text-xs font-medium text-red-500 hover:bg-red-50 rounded-xl w-full text-left transition-colors mt-1"
-                >
-                  <EyeOff size={14} />
-                  숨기기
-                </button>
               </div>
-            )}
+            </div>
 
             {/* Content */}
             <div className={`transition-all duration-500 ${isLocked ? 'blur-[6px] select-none opacity-40 grayscale-[0.5]' : ''}`}>
@@ -154,7 +192,7 @@ export const RecordsListTab: React.FC<RecordsListTabProps> = ({
 
             {/* Locked Overlay */}
             {isLocked && (
-              <div className="absolute inset-0 flex flex-col items-center justify-center z-10 bg-white/20">
+              <div className="absolute inset-0 flex flex-col items-center justify-center z-10 bg-white/20 rounded-[2rem]">
                 <div className="bg-white/90 backdrop-blur-md p-4 rounded-full mb-3 border border-mist-100 shadow-sm">
                   <Lock size={16} className="text-mist-400" />
                 </div>

--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -59,7 +59,7 @@ export const CATEGORIES = [
 export const MOOD_STICKERS = [
   { code: '포근', label: '포근', color: 'bg-point-100/50 text-point-600 border border-point-200' },
   { code: '멍함', label: '멍함', color: 'bg-mist-100 text-mist-500 border border-mist-200' },
-  { code: '반짝', label: '반짝', color: 'bg-lavender-100/50 text-lavender-600 border border-lavender-200' },
+  { code: '반짝', label: '반짝', color: 'bg-amber-100/50 text-amber-600 border border-amber-200' },
   { code: '잔잔', label: '잔잔', color: 'bg-blue-50 text-blue-500 border border-blue-100' },
   { code: '버팀', label: '버팀', color: 'bg-green-50 text-green-600 border border-green-200' },
   { code: '두근', label: '두근', color: 'bg-rose-50 text-rose-500 border border-rose-200' },

--- a/frontend/views/CommunityView.tsx
+++ b/frontend/views/CommunityView.tsx
@@ -3,7 +3,7 @@ import { PageHeader, MoodSticker } from '../components/UI';
 import { Heart, MessageCircle, Clock, ChevronDown, ChevronUp } from 'lucide-react';
 import { Record as RecordType } from '../types';
 
-const EXPAND_THRESHOLD = 120; // chars before collapsing text
+const EXPAND_THRESHOLD = 60; // chars before collapsing text
 
 interface CommunityViewProps {
   records?: RecordType[];
@@ -26,6 +26,11 @@ interface Post {
   timeAgo: string;
   isUserPost?: boolean;
 }
+
+const MOCK_COMMENTS = [
+  { id: 1, user: '지나가던_구름', text: '정말 공감되네요. 저도 오늘은 조금 천천히 걸어보려 합니다.', time: '1시간 전' },
+  { id: 2, user: '작은_위로', text: '그럴 때가 있죠. 자신만의 속도를 찾는 게 가장 중요한 것 같아요.', time: '30분 전' }
+];
 
 const CATEGORIES: { id: Category; label: string }[] = [
   { id: 'all', label: '전체' },
@@ -115,6 +120,19 @@ const MOCK_POSTS: Post[] = [
     comments: 3,
     timeAgo: '2일 전',
   },
+  {
+    id: 7,
+    category: 'workout',
+    username: '땀흘리는_여유',
+    question: '나의 한계를 마주하고 있는가?',
+    action: '오늘 하루 종일 바쁘게 움직였지만, 저녁에는 온전히 나만의 시간을 가지며 러닝머신 위를 달렸다. 숨이 차오를 때마다 복잡했던 머릿속이 맑아지는 기분이었다. 역시 땀 흘리는 시간은 배신하지 않는다. 내일도 이 감각을 잊지 않기를.',
+    mood: '포근',
+    moodCode: '포근',
+    level: '누군가의 기록',
+    likes: 82,
+    comments: 12,
+    timeAgo: '방금',
+  }
 ];
 
 
@@ -200,28 +218,28 @@ export const CommunityView: React.FC<CommunityViewProps> = ({ records = [] }) =>
         </div>
       </div>
 
-      {/* ── Weekly 많은 공감 ── */}
+      {/* ── Weekly Top 3 (이번 주 가장 공감받은 기록) ── */}
       {selectedCategory === 'all' && (
-        <div className="px-4 mb-8">
-          <div className="flex items-center gap-2 mb-4">
-            <Heart size={14} className="text-rose-400 fill-rose-300" />
-            <h3 className="text-xs font-bold text-mist-500 tracking-widest">이번 주 많이 울린 기록</h3>
-          </div>
-          <div className="flex flex-col gap-2.5">
-            {weeklyTop3.map((post) => (
-              <div
-                key={`top-${post.id}`}
-                className="flex items-center gap-3 bg-white/60 rounded-2xl px-4 py-3 border border-white/80 shadow-sm"
-              >
-                <div className="flex-1 min-w-0">
-                  <p className="text-[11px] font-bold text-mist-400 mb-0.5">@{post.username}</p>
-                  <p className="text-xs text-mist-600 line-clamp-2 leading-snug">{post.action}</p>
-                </div>
-                <div className="flex items-center gap-1 flex-shrink-0">
-                  <Heart size={13} className="text-rose-400 fill-rose-400" />
-                  <span className="text-[11px] font-bold text-mist-500">{post.likes}</span>
-                </div>
+        <div className="mb-10 relative">
+          <div className="px-5 pt-4 pb-2 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className="bg-white p-1.5 rounded-xl shadow-sm border border-mist-100">
+                <Heart size={14} className="text-rose-400 fill-rose-300" />
               </div>
+              <h3 className="text-[13px] font-bold text-mist-600 tracking-wide">이번 주 가장 공감받은 기록</h3>
+            </div>
+          </div>
+          
+          {/* 부각되는 디자인: 랭킹 배지와 특별한 테두리, 그리고 일반 피드와 동일한 세로 정렬(Vertical Flow) */}
+          <div className="flex flex-col gap-5 px-4 mt-3">
+            {weeklyTop3.map((post, index) => (
+                <PostItem
+                  key={`top-${post.id}`}
+                  post={post}
+                  liked={likedIds.has(post.id)}
+                  onToggleLike={(e) => toggleLike(post.id, e)}
+                  isHighlighted={true}
+                />
             ))}
           </div>
         </div>
@@ -267,15 +285,18 @@ interface PostItemProps {
   post: Post;
   liked: boolean;
   onToggleLike: (e: React.MouseEvent) => void;
+  isHighlighted?: boolean; // Flag to show a warm highlight styling instead of a rank
 }
 
-const PostItem: React.FC<PostItemProps> = ({ post, liked, onToggleLike }) => {
+const PostItem: React.FC<PostItemProps> = ({ post, liked, onToggleLike, isHighlighted }) => {
   const displayLikes = post.likes + (liked ? 1 : 0);
   const needsExpand = post.action.length > EXPAND_THRESHOLD || !!post.imageUrl;
   const [expanded, setExpanded] = useState(false);
+  const [showComments, setShowComments] = useState(false);
+  const [commentInput, setCommentInput] = useState('');
 
   return (
-    <div className="bg-white/70 rounded-3xl border border-white/70 shadow-sm overflow-hidden transition-all duration-300 hover:shadow-md hover:bg-white">
+    <div className={`bg-white/70 rounded-3xl border shadow-sm overflow-hidden transition-all duration-300 hover:shadow-md hover:bg-white relative ${isHighlighted ? 'border-rose-200/60 shadow-rose-100/50 shadow-lg ring-1 ring-rose-200/50' : 'border-white/70'}`}>
       {/* Header */}
       <div className="px-5 pt-5 pb-3 flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -335,10 +356,13 @@ const PostItem: React.FC<PostItemProps> = ({ post, liked, onToggleLike }) => {
       <div className="px-5 pb-4 flex items-center justify-between border-t border-mist-50/80 pt-3">
         <MoodSticker code={post.moodCode || post.mood} className="scale-90 origin-left" />
         <div className="flex items-center gap-4">
-          <div className="flex items-center gap-1.5 text-mist-400">
-            <MessageCircle size={15} />
+          <button 
+            onClick={() => setShowComments(!showComments)}
+            className={`flex items-center gap-1.5 transition-all duration-200 ${showComments ? 'text-point-500' : 'text-mist-400 hover:text-mist-500'}`}
+          >
+            <MessageCircle size={15} className={showComments ? 'fill-point-500' : ''} />
             <span className="text-[12px] font-semibold">{post.comments}</span>
-          </div>
+          </button>
           <button
             onClick={onToggleLike}
             className={`flex items-center gap-1.5 transition-all duration-200 active:scale-90 ${
@@ -350,6 +374,43 @@ const PostItem: React.FC<PostItemProps> = ({ post, liked, onToggleLike }) => {
           </button>
         </div>
       </div>
+
+      {/* Embedded Comments Section */}
+      {showComments && (
+        <div className="bg-mist-50/50 pt-3 pb-4 px-5 border-t border-mist-100/50 animate-fade-in">
+          <div className="flex flex-col gap-3 mb-4">
+            {MOCK_COMMENTS.map(c => (
+              <div key={c.id} className="flex gap-2.5">
+                <div className="w-6 h-6 shrink-0 rounded-full bg-mist-200 flex items-center justify-center">
+                  <span className="text-[9px] font-bold text-white">{c.user.charAt(0)}</span>
+                </div>
+                <div className="flex-1">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-[11px] font-bold text-mist-600">@{c.user}</span>
+                    <span className="text-[9px] text-mist-400">{c.time}</span>
+                  </div>
+                  <p className="text-[12px] text-mist-600 mt-0.5 leading-relaxed">{c.text}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="flex gap-2 items-center">
+            <input 
+              type="text" 
+              value={commentInput}
+              onChange={(e) => setCommentInput(e.target.value)}
+              placeholder="따뜻한 공감을 남겨주세요." 
+              className="flex-1 bg-white border border-mist-100 rounded-xl px-3 py-2 text-xs text-mist-600 placeholder-mist-300 focus:outline-none focus:border-point-300 transition-colors"
+            />
+            <button 
+              className="bg-mist-600 text-white px-3 py-2 rounded-xl text-xs font-bold hover:bg-mist-700 transition-colors"
+              onClick={() => { if(commentInput) { alert('댓글이 등록되었습니다.'); setCommentInput(''); } }}
+            >
+              등록
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/views/HomeView.tsx
+++ b/frontend/views/HomeView.tsx
@@ -80,7 +80,7 @@ export const HomeView: React.FC<HomeViewProps> = ({ state, onLogClick, onHistory
              {hasLoggedToday ? '기록이 안전하게 쌓이고 있어요.' : '하루를 돌아보며 방향을 만들어가요.'}
           </p>
         </div>
-        {lastRecord?.moodCode && (
+        {!hasLoggedToday && lastRecord?.moodCode && (
           <div className="shrink-0 flex flex-col items-center">
              <span className="text-[10px] text-mist-300 mb-1">최근 무드</span>
              <MoodSticker code={lastRecord.moodCode} className="opacity-100" />

--- a/frontend/views/LogEditorView.tsx
+++ b/frontend/views/LogEditorView.tsx
@@ -197,7 +197,7 @@ export const LogEditorView: React.FC<LogEditorViewProps> = ({ state, onSave, onC
 
       {/* Water Drop Micro-interaction */}
       {isSaving && (
-        <WaterDropOverlay leaving={saveState === 'leaving'} tone={mascotTone} />
+        <WaterDropOverlay leaving={saveState === 'leaving'} mood={mascotTone} />
       )}
     </div>
   );

--- a/frontend/views/PastDirectionsView.tsx
+++ b/frontend/views/PastDirectionsView.tsx
@@ -17,7 +17,7 @@ const PathSegment: React.FC<{
   if (direction === 'start') {
       return (
         <div className="w-full h-12 flex justify-center items-end relative overflow-hidden">
-            <div className="h-full w-[2px] bg-gradient-to-t from-mist-200 to-transparent"></div>
+            <div className="h-full w-[2px] bg-gradient-to-t from-point-200 to-transparent opacity-60"></div>
         </div>
       );
   }
@@ -26,7 +26,7 @@ const PathSegment: React.FC<{
       <svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="none" className="overflow-visible">
         <path
           d={direction === 'left-to-right' ? "M 20,0 C 20,50 80,50 80,100" : "M 80,0 C 80,50 20,50 20,100"}
-          fill="none" stroke={strokeColor} strokeWidth="2" strokeDasharray="4 4" vectorEffect="non-scaling-stroke" className="opacity-60"
+          fill="none" stroke={strokeColor} strokeWidth="2.5" strokeDasharray="5 5" vectorEffect="non-scaling-stroke" className="opacity-60"
         />
       </svg>
     </div>
@@ -60,21 +60,21 @@ export const PastDirectionsView: React.FC<PastDirectionsViewProps> = ({ pastDire
     const unlockDate = selectedDirection.reviewAt ? new Date(selectedDirection.reviewAt).toLocaleDateString() : '';
 
     return (
-      <div className="animate-slide-up pt-0 pb-24 relative z-10 bg-[#F5F7FA] min-h-screen">
-        <div className="sticky top-0 bg-[#F5F7FA]/90 backdrop-blur-md py-4 z-20 w-full px-4 border-b border-white/50 flex items-center gap-2">
-            <button onClick={() => setSelectedDirection(null)} className="p-1 text-mist-500 hover:text-point-500 transition-colors">
+      <div className="absolute inset-0 z-50 flex flex-col bg-white/60 backdrop-blur-2xl animate-fade-in overflow-y-auto no-scrollbar pb-24 shadow-2xl">
+        <div className="sticky top-0 bg-white/40 backdrop-blur-md py-4 z-20 w-full px-4 flex items-center gap-2 border-b border-white/50">
+            <button onClick={() => setSelectedDirection(null)} className="p-1.5 text-mist-500 hover:text-point-600 hover:bg-white/50 rounded-full transition-colors">
               <ChevronLeft size={24} />
             </button>
-            <span className="text-sm font-bold text-mist-500 ml-1">나의 궤적 목록</span>
+            <span className="text-sm font-bold text-mist-600 ml-1">나의 방향 목록</span>
         </div>
 
-        <div className="px-6 mt-10 mb-10 text-center animate-fade-in">
-            <h2 className="text-2xl font-bold text-mist-600 leading-snug mb-5 whitespace-pre-line px-2">
+        <div className="px-6 mt-10 mb-10 text-center animate-slide-up">
+            <h2 className="text-[22px] font-bold text-mist-600 leading-snug mb-5 whitespace-pre-line px-2 drop-shadow-sm">
                 "{selectedDirection.question}"
             </h2>
-            <div className="inline-flex items-center gap-2 bg-white px-5 py-2 rounded-full shadow-sm border border-mist-100">
+            <div className="inline-flex items-center gap-2 bg-white/70 backdrop-blur-sm px-5 py-2.5 rounded-full shadow-sm border border-white">
                 <span className="text-[11px] font-bold text-point-500 uppercase tracking-widest">Period</span>
-                <span className="text-sm text-mist-500 font-bold">{startDate} ~ {endDate}</span>
+                <span className="text-sm text-mist-600 font-bold">{startDate} ~ {endDate}</span>
             </div>
         </div>
 
@@ -82,21 +82,21 @@ export const PastDirectionsView: React.FC<PastDirectionsViewProps> = ({ pastDire
             {!showSummary ? (
                 <SoftButton 
                     onClick={isLocked ? undefined : handleSummarize} 
-                    className={`w-full !rounded-2xl !py-5 shadow-sm bg-white border border-point-100 font-bold ${isLocked ? 'opacity-60 cursor-not-allowed grayscale' : 'hover:shadow-md'}`}
+                    className={`w-full !rounded-2xl !py-5 shadow-sm bg-white/80 backdrop-blur-sm border border-white font-bold ${isLocked ? 'opacity-60 cursor-not-allowed grayscale' : 'hover:shadow-md hover:border-point-100 hover:bg-white'}`}
                     variant="secondary"
                     disabled={isLocked}
                 >
                     {isSummarizing ? (
                         <span className="text-point-500 flex gap-2 items-center"><Sparkles size={16} className="animate-spin"/> 지난 조각들을 엮는 중...</span>
                     ) : isLocked ? (
-                        <span className="text-mist-400 flex gap-2 items-center text-sm"><Lock size={16} /> {unlockDate}까지 잠겨있습니다</span>
+                        <span className="text-mist-500 flex gap-2 items-center text-sm"><Lock size={16} /> {unlockDate}까지 회고가 잠겨있습니다</span>
                     ) : (
                         <span className="text-point-500 flex gap-2 items-center"><Sparkles size={16} /> AI 회고 리포트 받아보기</span>
                     )}
                 </SoftButton>
             ) : (
-                <div className="animate-fade-in bg-white rounded-3xl border border-point-100 shadow-sm overflow-hidden">
-                    <div className="flex justify-center py-4 bg-point-50/50 border-b border-point-50">
+                <div className="animate-fade-in bg-white/90 backdrop-blur-md rounded-3xl border border-white shadow-lg shadow-point-100/30 overflow-hidden">
+                    <div className="flex justify-center py-4 bg-point-50/50 border-b border-white">
                         <span className="text-[11px] font-bold text-point-500 uppercase tracking-widest flex items-center gap-1.5">
                             <Sparkles size={12} /> AI 요약 리포트
                         </span>
@@ -114,10 +114,10 @@ export const PastDirectionsView: React.FC<PastDirectionsViewProps> = ({ pastDire
         <div className="px-6 mb-12 animate-slide-up" style={{ animationDelay: '0.2s' }}>
              <div className="flex items-center justify-between mb-5 px-1">
                  <div className="flex items-center gap-2">
-                    <span className="text-[11px] font-bold text-mist-400 uppercase tracking-widest">Recorded Steps</span>
+                    <span className="text-[11px] font-bold text-mist-500 uppercase tracking-widest">Recorded Flows</span>
                  </div>
                  {isLocked && (
-                    <div className="flex items-center gap-1.5 bg-mist-100 px-3 py-1 rounded-full text-mist-500 border border-mist-200 shadow-inner">
+                    <div className="flex items-center gap-1.5 bg-white/50 backdrop-blur-sm px-3 py-1.5 rounded-full text-mist-500 border border-white shadow-sm">
                          <Lock size={12} /> <span className="text-[10px] font-bold tracking-wide">{unlockDate} 해제</span>
                     </div>
                  )}
@@ -125,12 +125,12 @@ export const PastDirectionsView: React.FC<PastDirectionsViewProps> = ({ pastDire
              
              <div className="flex flex-col gap-4">
                  {flowRecords.length === 0 ? (
-                    <div className="text-center py-12 bg-white/50 rounded-3xl border border-white">
-                        <p className="text-mist-400 text-sm font-medium">기록된 여정이 없습니다.</p>
+                    <div className="text-center py-12 bg-white/40 backdrop-blur-sm rounded-3xl border border-white shadow-inner">
+                        <p className="text-mist-500 text-sm font-medium drop-shadow-sm">기록된 궤적이 없습니다.</p>
                     </div>
                  ) : (
                     flowRecords.map((record) => (
-                        <Card key={record.id} className={`!p-6 !rounded-[1.5rem] border border-white shadow-sm transition-transform active:scale-[0.99] ${record.isPinned ? 'bg-white shadow-md border-point-100 ring-1 ring-point-50' : 'bg-white/80'}`}>
+                        <Card key={record.id} className={`!p-5 border border-white shadow-sm transition-transform active:scale-[0.99] ${record.isPinned ? 'bg-white shadow-md border-point-100 ring-1 ring-point-50' : 'bg-white/70 backdrop-blur-md'}`}>
                             <div className={`transition-all duration-700 ${isLocked ? 'blur-[6px] opacity-40 select-none grayscale-[0.5]' : ''}`}>
                                 <div className="flex justify-between items-start mb-4">
                                     <span className="text-xs font-bold text-mist-400 tracking-wider">
@@ -139,11 +139,11 @@ export const PastDirectionsView: React.FC<PastDirectionsViewProps> = ({ pastDire
                                     {record.isPinned && <Pin size={14} className="text-point-400" />}
                                 </div>
                                 <div className="flex items-center gap-2.5 mb-3">
-                                    {record.moodCode && <MoodSticker code={record.moodCode} />}
-                                    {record.action && <span className="text-sm font-bold text-mist-600 line-clamp-2">{record.action}</span>}
+                                    {record.moodCode && <MoodSticker code={record.moodCode} className="scale-90" />}
+                                    {record.action && <span className="text-[14px] font-bold text-mist-600 line-clamp-2 leading-relaxed">{record.action}</span>}
                                 </div>
                                 {record.oneWordText && (
-                                    <p className="text-mist-600 text-[15px] leading-relaxed font-normal">
+                                    <p className="text-mist-500 text-[14px] leading-relaxed font-medium bg-white/50 p-3 rounded-2xl border border-white">
                                         {record.oneWordText}
                                     </p>
                                 )}
@@ -156,15 +156,15 @@ export const PastDirectionsView: React.FC<PastDirectionsViewProps> = ({ pastDire
         
         {flowRecords.length > 0 && (
             <div className="px-6 pb-12 animate-slide-up" style={{ animationDelay: '0.3s' }}>
-                <div className="relative h-48 w-full bg-gradient-to-b from-white/60 to-white rounded-3xl border border-white shadow-sm overflow-hidden">
+                <div className="relative h-48 w-full bg-gradient-to-b from-white/40 to-white/70 backdrop-blur-md rounded-3xl border border-white shadow-sm overflow-hidden">
                      {flowRecords.map((record, i) => (
                          <ForestObject key={record.id} index={i} type={record.action} isLocked={isLocked} />
                      ))}
-                     <div className="absolute bottom-0 left-0 w-full h-12 bg-gradient-to-t from-white via-white/80 to-transparent pointer-events-none"></div>
+                     <div className="absolute bottom-0 left-0 w-full h-12 bg-gradient-to-t from-white/80 via-white/40 to-transparent pointer-events-none"></div>
                 </div>
-                <div className="flex justify-center mt-4">
-                    <p className="text-xs font-bold text-mist-400 bg-white px-4 py-1.5 rounded-full border border-mist-100 shadow-sm">
-                        {flowRecords.length} 개의 발자국이 남았습니다.
+                <div className="flex justify-center mt-5">
+                    <p className="text-xs font-bold text-mist-500 bg-white/80 backdrop-blur-sm px-5 py-2 rounded-full border border-white shadow-sm">
+                        {flowRecords.length} 개의 발자국이 길 위에 남아있습니다.
                     </p>
                 </div>
             </div>
@@ -176,46 +176,82 @@ export const PastDirectionsView: React.FC<PastDirectionsViewProps> = ({ pastDire
   const sortedDirections = [...pastDirections].sort((a, b) => b.createdAt - a.createdAt);
 
   return (
-    <div className="animate-slide-up pt-2 pb-0 h-full flex flex-col relative">
+    <div className="animate-fade-in pt-2 pb-0 h-full flex flex-col relative w-full">
       <div className="flex items-center gap-2 mb-2 pl-1 px-4">
-        <button onClick={onBack} className="p-2 -ml-2 text-mist-400 hover:text-mist-600 hover:bg-white/50 rounded-full transition-colors">
+        <button onClick={onBack} className="p-2 -ml-2 text-mist-400 hover:text-mist-600 hover:bg-white/30 rounded-full transition-colors active:scale-95">
              <ChevronLeft size={24} />
         </button>
       </div>
       
-      <PageHeader title="나의 궤적" subtitle="지나온 길들은 당신만의 기록이 됩니다." />
+      <PageHeader title="지나온 방향들" subtitle="걸어온 곡선들이 온전히 당신만의 궤적이 됩니다." />
 
       <div className="flex-1 overflow-y-auto no-scrollbar relative pb-32">
         {sortedDirections.length === 0 && (
             <div className="text-center py-20 opacity-60">
                 <MapPin size={40} className="text-mist-300 mx-auto mb-4" />
-                <p className="text-mist-400 font-medium">아직 지나온 길이 없습니다.</p>
+                <p className="text-mist-400 font-medium">아직 지나온 길(방향)이 없습니다.</p>
             </div>
         )}
 
-        <div className="relative max-w-sm mx-auto w-full px-6">
-            <div className="flex justify-center mb-2">
-                <div className="w-3.5 h-3.5 rounded-full bg-point-300 ring-4 ring-point-100/50 shadow-sm"></div>
+        {/* 궤적 박스들을 담으면서도 여백을 줄 수 있는 컨테이너 */}
+        <div className="relative max-w-sm mx-auto w-full px-6 pt-4">
+            <div className="flex justify-center mb-0">
+                <div className="w-3 h-3 rounded-full bg-point-300 ring-4 ring-point-100/50 shadow-sm z-10"></div>
             </div>
 
             {sortedDirections.map((dir, index) => {
                 const isEven = index % 2 === 0;
-                const prevConnector = index === 0 ? <PathSegment direction="start" height={40} /> : <PathSegment direction={isEven ? "left-to-right" : "right-to-left"} height={60} />;
+                const prevConnector = index === 0 ? <PathSegment direction="start" height={30} /> : <PathSegment direction={isEven ? "left-to-right" : "right-to-left"} height={55} />;
+                
+                const flowRecords = records
+                    .filter(r => r.directionQuestion === dir.question && !r.isHidden)
+                    .sort((a, b) => a.timestamp - b.timestamp);
+                
+                const count = flowRecords.length;
+                const dayDiff = Math.max(1, Math.ceil(((dir.endedAt || Date.now()) - dir.createdAt) / (1000 * 60 * 60 * 24)));
+                
+                const moodCounts = flowRecords.reduce((acc, r) => {
+                    if (r.moodCode) acc[r.moodCode] = (acc[r.moodCode] || 0) + 1;
+                    return acc;
+                }, {} as Record<string, number>);
+                
+                const topMood = Object.entries(moodCounts).sort((a, b) => b[1] - a[1])[0]?.[0];
 
                 return (
-                    <div key={dir.id} className="relative">
+                    <div key={dir.id} className="relative w-full">
                         {prevConnector}
-                        <div onClick={() => setSelectedDirection(dir)} className={`relative flex ${isEven ? 'justify-end' : 'justify-start'} -mt-4 mb-2 z-10 group`}>
-                            <div className={`w-[80%] transition-all duration-300 hover:scale-[1.03] active:scale-95 cursor-pointer`}>
-                                <div className={`relative bg-white/80 backdrop-blur-md p-6 rounded-3xl border border-white shadow-sm hover:shadow-md ${dir.isActive ? 'border-point-200 bg-white' : ''}`}>
-                                    <span className="text-[10px] text-mist-400 block mb-2.5 font-bold tracking-wide">
-                                        {new Date(dir.createdAt).toLocaleDateString()}
-                                        {dir.endedAt ? ` ~ ${new Date(dir.endedAt).toLocaleDateString()}` : ' ~ 현재'}
+                        <div onClick={() => setSelectedDirection(dir)} className={`relative flex ${isEven ? 'justify-end' : 'justify-start'} -mt-3 mb-1 z-10 group`}>
+                            <div className={`w-[85%] transition-all duration-300 hover:scale-[1.02] active:scale-95 cursor-pointer`}>
+                                <div className={`relative backdrop-blur-xl p-6 rounded-[2rem] shadow-lg border border-white ${dir.isActive ? 'border-point-200 bg-white/90 shadow-point-100/30 ring-1 ring-point-50' : 'bg-white/60 hover:bg-white/80 shadow-mist-200/10'}`}>
+                                    <span className="text-[10px] text-mist-400 block mb-2 font-bold tracking-widest uppercase opacity-80">
+                                        {new Date(dir.createdAt).toLocaleDateString(undefined, { year: '2-digit', month: '2-digit', day: '2-digit' })}
+                                        {dir.endedAt ? ` ~ ${new Date(dir.endedAt).toLocaleDateString(undefined, { year: '2-digit', month: '2-digit', day: '2-digit' })}` : ' ~ 현재'}
                                     </span>
-                                    <h3 className="text-mist-600 text-[15px] font-bold leading-relaxed line-clamp-2">
+                                    <h3 className="text-mist-600 text-[15px] font-bold leading-relaxed line-clamp-2 drop-shadow-sm mb-4">
                                         {dir.question}
                                     </h3>
-                                    <div className={`absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border-[3px] border-point-300 shadow-sm ${isEven ? '-left-[15%] md:-left-[20%]' : '-right-[15%] md:-right-[20%]'}`}></div>
+                                    
+                                    <div className="flex flex-wrap items-center gap-2 mt-4">
+                                        <div className="flex items-center gap-1 bg-white/50 px-2.5 py-1.5 rounded-full border border-white shadow-sm">
+                                            <span className="text-[9px] font-bold text-mist-400 tracking-wider">기록</span>
+                                            <span className="text-[11px] font-bold text-point-500">{count}개</span>
+                                        </div>
+                                        <div className="flex items-center gap-1 bg-white/50 px-2.5 py-1.5 rounded-full border border-white shadow-sm">
+                                            <span className="text-[9px] font-bold text-mist-400 tracking-wider">기간</span>
+                                            <span className="text-[11px] font-bold text-mist-500">{dayDiff}일</span>
+                                        </div>
+                                        {topMood && (
+                                            <div className="flex items-center gap-1 bg-white/50 pl-1.5 pr-2.5 py-1 rounded-full border border-white shadow-sm">
+                                                <div className="w-[20px] h-[20px] flex items-center justify-center -ml-0.5">
+                                                     <MoodSticker code={topMood} className="scale-[0.55] origin-center shadow-none" />
+                                                </div>
+                                                <span className="text-[9px] font-bold text-mist-400 tracking-wider ml-0.5">주된 감정</span>
+                                            </div>
+                                        )}
+                                    </div>
+                                    
+                                    {/* 현재 위치를 나타내는 작은 노드 마커 */}
+                                    <div className={`absolute top-1/2 -translate-y-1/2 w-4 h-4 rounded-full bg-white border-[3.5px] shadow-sm ${dir.isActive ? 'border-point-300' : 'border-mist-200'} ${isEven ? '-left-[15%] md:-left-[20%]' : '-right-[15%] md:-right-[20%]'}`}></div>
                                 </div>
                             </div>
                         </div>
@@ -224,15 +260,15 @@ export const PastDirectionsView: React.FC<PastDirectionsViewProps> = ({ pastDire
             })}
             
             {sortedDirections.length > 0 && (
-                <div className="relative h-24 w-full overflow-hidden">
+                <div className="relative h-32 w-full overflow-hidden mt-2">
                      <PathSegment direction={sortedDirections.length % 2 === 0 ? "left-to-right" : "right-to-left"} height={120} />
-                     <div className="absolute inset-0 bg-gradient-to-t from-[#F5F7FA] via-[#F5F7FA]/80 to-transparent"></div>
                 </div>
             )}
         </div>
       </div>
       
-      <div className="absolute bottom-0 left-0 w-full h-28 bg-gradient-to-t from-[#F5F7FA] via-[#F5F7FA]/90 to-transparent pointer-events-none z-20"></div>
+      {/* 부드럽게 사라지는 하단 그라데이션 - 칙칙한 색 대신 흰색 투명도로 대체하여 dream-bg와 어울리게 함 */}
+      <div className="absolute bottom-0 left-0 w-full h-32 bg-gradient-to-t from-white/40 via-white/10 to-transparent pointer-events-none z-20"></div>
     </div>
   );
 };

--- a/frontend/views/RecordsView.tsx
+++ b/frontend/views/RecordsView.tsx
@@ -55,7 +55,7 @@ export const RecordsView: React.FC<RecordsViewProps> = ({
     },
     {} as Record<string, number>,
   );
-  const topMoods = Object.entries(moodCounts).sort((a, b) => b[1] - a[1]).slice(0, 3);
+  const topMoods = Object.entries(moodCounts).sort((a, b) => b[1] - a[1]).slice(0, 1);
 
   const photoRecords = useMemo(
     () =>
@@ -214,24 +214,44 @@ export const RecordsView: React.FC<RecordsViewProps> = ({
         </div>
       </div>
 
-      {/* ── Stats Cards ── */}
       <div className="px-4 mb-6">
         <div className="grid grid-cols-3 gap-3">
-          <div className="bg-white/70 p-4 rounded-3xl border border-white shadow-sm flex flex-col justify-center items-center min-h-[96px]">
-            <span className="text-[10px] font-bold text-mist-400 uppercase tracking-widest mb-1.5 text-center">Records</span>
-            <span className="text-3xl font-bold text-point-500">{monthlyRecords.length}</span>
+          {/* Records Card */}
+          <div className="bg-white/70 p-4 rounded-[2rem] border border-white shadow-sm flex flex-col items-center min-h-[105px]">
+            <div className="h-6 flex items-center mb-1">
+              <span className="text-[10px] font-bold text-mist-400 uppercase tracking-widest text-center">Records</span>
+            </div>
+            <div className="flex-1 flex items-center justify-center w-full">
+              <span className="text-3xl font-bold text-point-500 leading-none">{monthlyRecords.length}</span>
+            </div>
           </div>
-          <div className="bg-white/70 p-4 rounded-3xl border border-white shadow-sm flex flex-col justify-center items-center min-h-[96px]">
-            <span className="text-[10px] font-bold text-mist-400 uppercase tracking-widest mb-1.5 text-center">Photos</span>
-            <span className="text-3xl font-bold text-mist-600">{photoRecords.length}</span>
-            <span className="text-[10px] text-mist-300 mt-1">{photoCoverage}%</span>
+          
+          {/* Photos Card */}
+          <div className="bg-white/70 p-4 rounded-[2rem] border border-white shadow-sm flex flex-col items-center min-h-[105px]">
+            <div className="h-6 flex items-center mb-1">
+              <span className="text-[10px] font-bold text-mist-400 uppercase tracking-widest text-center">Photos</span>
+            </div>
+            <div className="flex-1 flex items-center justify-center w-full">
+              <div className="relative flex items-baseline">
+                <span className="text-3xl font-bold text-mist-600 leading-none">{photoRecords.length}</span>
+                {photoCoverage > 0 && (
+                  <span className="absolute left-full ml-1 bottom-0.5 text-[10px] text-mist-300 font-bold whitespace-nowrap">
+                    {photoCoverage}%
+                  </span>
+                )}
+              </div>
+            </div>
           </div>
-          <div className="bg-white/70 p-4 rounded-3xl border border-white shadow-sm flex flex-col justify-center items-center min-h-[96px]">
-            <span className="text-[10px] font-bold text-mist-400 uppercase tracking-widest mb-2 text-center">Top Moods</span>
-            <div className="flex justify-center flex-wrap gap-1">
+
+          {/* Top Mood Card */}
+          <div className="bg-white/70 p-4 rounded-[2rem] border border-white shadow-sm flex flex-col items-center min-h-[105px]">
+            <div className="h-6 flex items-center mb-1">
+              <span className="text-[10px] font-bold text-mist-400 uppercase tracking-widest text-center">Top Mood</span>
+            </div>
+            <div className="flex-1 flex items-center justify-center w-full">
               {topMoods.length > 0 ? (
                 topMoods.map(([code]) => (
-                  <MoodSticker key={code} code={code} className="scale-90 opacity-100 px-2 py-1" />
+                  <MoodSticker key={code} code={code} className="scale-90 opacity-100" />
                 ))
               ) : (
                 <span className="text-sm text-mist-300">-</span>


### PR DESCRIPTION
## 작업 내용
- 방향 기준으로 ERD 용어와 컬럼 정의를 재정리.
- 커밋 규칙과 MR 규칙 문서를 추가.
- 온보딩과 방향 설정 화면이 같은 입력 폼을 사용하도록 공통화.
- 방향 관련 화면 문구를 방향 기준으로 통일.
- 기록 생성/수정 요청에 `moodCode`를 반영하고 응답 필드를 확장.
- 기록 수정 시 `PUT` 경로를 추가하고 중복 생성 방어 로직을 보강.
- 홈, 기록, 회고, 커뮤니티 화면의 카드와 목록 구성을 정리.

## 확인 방법
- 온보딩과 방향 설정 화면에서 동일한 입력 폼이 보이는지 확인
- 기록 생성/수정 시 `moodCode`가 저장되고 응답에 포함되는지 확인

## 영향 범위
- 문서: ERD, 커밋 규칙, MR 규칙
- 백엔드: 기록 생성/수정/조회 DTO 및 서비스
- 프론트: 방향 설정 화면, 온보딩, 홈, 기록, 회고, 커뮤니티 화면

